### PR TITLE
Fix for bare-make workflow

### DIFF
--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -42,10 +42,12 @@ jobs:
             tar -czf "$artifacts/${{ env.MODULE_NAME }}-${{ needs.build.outputs.version }}-${folder_name}.tar.gz" -C "prebuilds" "$folder_name"
           done
 
+      - run: ls -laR
+
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "prebuilds/*"
+          artifacts: "artifacts/*"
           artifactErrorsFailBuild: true
           allowUpdates: true
           replacesArtifacts: true

--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -35,7 +35,12 @@ jobs:
         with:
           path: prebuilds
 
-      - run: ls -alR prebuilds
+      - run: |
+          mkdir -p artifacts
+          for folder in prebuilds/*/; do
+            folder_name=$(basename "$folder")
+            tar -czf "$artifacts/${{ env.MODULE_NAME }}-${{ needs.build.outputs.version }}-${folder_name}.tar.gz" -C "sodium-native" "$folder_name"
+          done
 
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -39,7 +39,7 @@ jobs:
           mkdir -p artifacts
           for folder in prebuilds/*/; do
             folder_name=$(basename "$folder")
-            tar -czf "$artifacts/${{ env.MODULE_NAME }}-${{ needs.build.outputs.version }}-${folder_name}.tar.gz" -C "prebuilds" "$folder_name"
+            tar -czf "artifacts/${{ env.MODULE_NAME }}-${{ needs.build.outputs.version }}-${folder_name}.tar.gz" -C "prebuilds" "$folder_name"
           done
 
       - run: ls -laR

--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -30,15 +30,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-
       - name: Download artifacts
         uses: actions/download-artifact@v4
+        with:
+          path: prebuilds
+
+      - run: ls -alR prebuilds
 
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "${{ env.MODULE_NAME }}-${{ needs.build.outputs.version }}-*/*.tar.gz"
+          artifacts: "prebuilds/*"
           artifactErrorsFailBuild: true
           allowUpdates: true
           replacesArtifacts: true
+          tag: ${{ needs.build.outputs.version }}

--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -26,7 +26,6 @@ jobs:
       arch: ${{ matrix.arch }}
 
   release:
-    if: ${{ startsWith(github.ref, 'refs/tags') }}
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -39,7 +38,7 @@ jobs:
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "${{ env.MODULE_NAME }}-${{ env.MODULE_VERSION }}-*/*.tar.gz"
+          artifacts: "${{ env.MODULE_NAME }}-${{ needs.build.outputs.version }}-*/*.tar.gz"
           artifactErrorsFailBuild: true
           allowUpdates: true
           replacesArtifacts: true

--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -1,96 +1,29 @@
 name: Generate prebuilds
 
 on:
-  push:
-    branches: [main]
-    tags:
-      - "*"
+  workflow_dispatch:
+    inputs:
+      module_version:
+        description: 'Module version'
+        required: true
+        default: 'latest'
 
 env:
   NODE_VERSION: 18
   MODULE_NAME: "sodium-native"
-  MODULE_VERSION: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'latest' }}
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 10
     strategy:
-      fail-fast: false
       matrix:
-        arch: ["arm", "arm64", "x64"]
-        platform: ["android"]
-    name: ${{ matrix.platform }}-${{ matrix.arch }}
-    steps:
-      - name: Assert env.MODULE_VERSION is set
-        if: ${{ env.MODULE_VERSION == '' }}
-        run: echo "env.MODULE_VERSION must be set" && exit 1
-
-      - uses: actions/checkout@v4
-
-      - name: Setup NDK
-        uses: nttld/setup-ndk@v1
-        id: setup-ndk
-        with:
-          ndk-version: r26 # https://github.com/android/ndk/wiki/Unsupported-Downloads#r24
-          add-to-path: false
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Download npm package and unpack
-        run: npm pack ${{ env.MODULE_NAME }}@${{ env.MODULE_VERSION }} | xargs tar -zxvf
-
-      - run: npm install -g bare-make
-
-      - name: Install deps for package
-        working-directory: ./package
-        run: npm install
-
-      - name: Install patched cmake-napi
-        working-directory: ./package
-        run: npm install cmake-napi@github:digidem/cmake-napi-nodejs-mobile
-
-      - name: Generate
-        working-directory: ./package
-        env:
-          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
-        run: bare-make generate --platform ${{ matrix.platform }} --arch ${{ matrix.arch }}
-
-      - name: Build
-        working-directory: ./package
-        run: bare-make build
-
-      - name: Install
-        working-directory: ./package
-        run: bare-make install
-
-      - name: Define target
-        id: define_target
-        run: echo "target=${{ matrix.platform }}-${{ matrix.arch }}" >> "$GITHUB_OUTPUT"
-
-      - name: Upload original prebuild artifacts # mostly for debugging purposes
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.define_target.outputs.target }}
-          path: ./package/prebuilds/${{ steps.define_target.outputs.target }}
-
-      # The below steps are needed for the release job
-
-      - name: Derive release artifact name
-        id: artifact-name
-        run: echo "NAME=${{ env.MODULE_NAME }}-${{ env.MODULE_VERSION }}-${{ steps.define_target.outputs.target }}" >> "$GITHUB_OUTPUT"
-
-      - name: Prepare release artifact
-        run: tar -czf ${{ steps.artifact-name.outputs.NAME }}.tar.gz --directory=./package/prebuilds/${{ steps.define_target.outputs.target }} .
-
-      - name: Upload release artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.artifact-name.outputs.NAME }}
-          path: ./${{ steps.artifact-name.outputs.NAME }}.tar.gz
+        platform: [android]
+        arch: [arm64, x64, arm]
+    uses: digidem/nodejs-mobile-prebuilds/.github/workflows/prebuild.yml@main
+    with:
+      module_name: ${{ env.MODULE_NAME }}
+      module_version: ${{ inputs.module_version }}
+      platform: ${{ matrix.platform }}
+      arch: ${{ matrix.arch }}
 
   release:
     if: ${{ startsWith(github.ref, 'refs/tags') }}
@@ -101,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -20,7 +20,7 @@ jobs:
         arch: [arm64, x64, arm]
     uses: digidem/nodejs-mobile-prebuilds/.github/workflows/prebuild.yml@main
     with:
-      module_name: ${{ env.MODULE_NAME }}
+      module_name: "sodium-native"
       module_version: ${{ inputs.module_version }}
       platform: ${{ matrix.platform }}
       arch: ${{ matrix.arch }}

--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -4,13 +4,15 @@ on:
   workflow_dispatch:
     inputs:
       module_version:
-        description: 'Module version'
+        description: "Module version"
         required: true
-        default: 'latest'
-
-env:
-  NODE_VERSION: 18
-  MODULE_NAME: "sodium-native"
+        default: "latest"
+        type: string
+      publish_release:
+        description: "Publish release"
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   build:
@@ -26,29 +28,8 @@ jobs:
       arch: ${{ matrix.arch }}
 
   release:
+    if: ${{ inputs.publish_release }}
     needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: prebuilds
-
-      - run: |
-          mkdir -p artifacts
-          for folder in prebuilds/*/; do
-            folder_name=$(basename "$folder")
-            tar -czf "artifacts/${{ env.MODULE_NAME }}-${{ needs.build.outputs.version }}-${folder_name}.tar.gz" -C "prebuilds" "$folder_name"
-          done
-
-      - run: ls -laR
-
-      - name: Create GitHub Release
-        uses: ncipollo/release-action@v1
-        with:
-          artifacts: "artifacts/*"
-          artifactErrorsFailBuild: true
-          allowUpdates: true
-          replacesArtifacts: true
-          tag: ${{ needs.build.outputs.version }}
+    uses: digidem/nodejs-mobile-prebuilds/.github/workflows/release.yml@main
+    with:
+      module_version: ${{ needs.build.outputs.module_version }}

--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         platform: [android]
         arch: [arm64, x64, arm]
-    uses: digidem/nodejs-mobile-prebuilds/.github/workflows/prebuild.yml@main
+    uses: digidem/nodejs-mobile-bare-prebuilds/.github/workflows/prebuild.yml@main
     with:
       module_name: "sodium-native"
       module_version: ${{ inputs.module_version }}
@@ -30,6 +30,6 @@ jobs:
   release:
     if: ${{ inputs.publish_release }}
     needs: build
-    uses: digidem/nodejs-mobile-prebuilds/.github/workflows/release.yml@main
+    uses: digidem/nodejs-mobile-bare-prebuilds/.github/workflows/release.yml@main
     with:
       module_version: ${{ needs.build.outputs.module_version }}

--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -39,7 +39,7 @@ jobs:
           mkdir -p artifacts
           for folder in prebuilds/*/; do
             folder_name=$(basename "$folder")
-            tar -czf "$artifacts/${{ env.MODULE_NAME }}-${{ needs.build.outputs.version }}-${folder_name}.tar.gz" -C "sodium-native" "$folder_name"
+            tar -czf "$artifacts/${{ env.MODULE_NAME }}-${{ needs.build.outputs.version }}-${folder_name}.tar.gz" -C "prebuilds" "$folder_name"
           done
 
       - name: Create GitHub Release

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Digital Democracy
+Copyright (c) 2024 Awana Digital
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -7,24 +7,49 @@
 ### Requirements
 
 - Node 18
-- Android NDK 24.0.8215888
-  - (optional) exported `ANDROID_NDK_PATH` environment variable
+- Android NDK (CI uses version 27.2.12479018)
+  - (optional) exported `ANDROID_NDK_HOME` environment variable
 
 ### General steps
 
-Should be clear enough to follow the workflow steps but in summary:
+Should be clear enough to follow the [reusable workflow steps](https://github.com/digidem/nodejs-mobile-bare-prebuilds/blob/main/.github/workflows/prebuild.yml) but in summary:
 
-1. Download the npm tarball package and unzip e.g. `npm pack sodium-native@latest | xargs tar -zxvf`
-
-2. Navigate to unzipped directory and run `npx prebuild-for-nodejs-mobile TARGET`, where `TARGET` is an accepted value from the [`prebuild-for-nodejs-mobile`](https://github.com/staltz/prebuild-for-nodejs-mobile) CLI
-   - if you don't have the `ANDROID_NDK_PATH` environment variable exported, you may run the command like so: `ANDROID_NDK_HOME=/path/to/ndk npx prebuild-for-nodejs-mobile TARGET`
+1. Download the npm tarball package and unzip e.g.
+    ```
+    npm pack sodium-native@latest | xargs tar -zxvf
+    ```
+2. Navigate to unzipped directory:
+   ```
+   cd package
+   ```
+3. Install dependencies:
+   ```
+   npm install
+   ```
+4. Install [patched `cmake-napi`](https://github.com/digidem/cmake-napi-nodejs-mobile):
+   ```
+   npm install cmake-napi@github:digidem/cmake-napi-nodejs-mobile
+   ```
+5. Install [bare-make](https://github.com/holepunchto/bare-make) globally:
+   ```
+   npm install -g bare-make@latest
+   ```
+6. Generate, build and install:
+   ```
+   bare-make generate --platform android --arch arm64
+   bare-make build
+   bare-make install
+   ```
 
 ## Creating a release
 
-1. Create a git tag that matches the version of the module you want to create prebuilds for e.g. `git tag 1.0.0`
+1. Navigate to the [Generate Prebuilds workflow](https://github.com/digidem/sodium-native-nodejs-mobile/actions/workflows/prebuilds.yml)
+2. Manually dispatch the worflow with the version you want to build, ensuring that "Publish Release" is checked.
 
-2. Push the tag to the remote e.g. `git push origin 1.0.0`
+## Contributing
 
-3. The workflow uses the tag version to create the prebuilds and then publish a release with those prebuilds.
+We welcome contributions to this repository. If you have an idea for a new feature or have found a bug, please open an issue or submit a pull request.
 
-4. The relevant artifacts will show up in GitHub Releases. Each artifact is a tarball containing the `.node` files for the target-specific prebuild.
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for more details.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sodium-native-nodejs-mobile
 
-[NodeJS Mobile](https://github.com/nodejs-mobile/nodejs-mobile) prebuilds for [`sodium-native`](https://github.com/sodium-friends/sodium-native)
+[NodeJS Mobile](https://github.com/nodejs-mobile/nodejs-mobile) prebuilds for [`sodium-native`](https://github.com/holepunchto/sodium-native)
 
 ## Working locally
 


### PR DESCRIPTION
Fix for using bare-make, as required for latest versions of modules maintained by holepunch. Uses a re-usable workflow at https://github.com/digidem/nodejs-mobile-bare-prebuilds